### PR TITLE
Replace wildcard imports with explicit imports

### DIFF
--- a/Inverter.glyphsFilter/Contents/Info.plist
+++ b/Inverter.glyphsFilter/Contents/Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundleName</key>
 	<string>Inverter</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.4</string>
+	<string>2.0.5</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>10</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright, Rainer Erich Scheichelbauer, 2015-2018</string>
 	<key>NSPrincipalClass</key>

--- a/Inverter.glyphsFilter/Contents/Resources/plugin.py
+++ b/Inverter.glyphsFilter/Contents/Resources/plugin.py
@@ -16,8 +16,8 @@ from __future__ import division, print_function, unicode_literals
 ###########################################################################################################
 
 import objc
-from GlyphsApp import *
-from GlyphsApp.plugins import *
+from GlyphsApp import Glyphs, GSPath, GSNode
+from GlyphsApp.plugins import FilterWithDialog
 from AppKit import NSAffineTransform, NSPoint
 from math import tan, pi
 


### PR DESCRIPTION
Follows the recent import-cleanup pattern applied across the Glyphs plug-in repos: replace wildcard imports with explicit ones.

### Changes
- `from GlyphsApp import *` → `from GlyphsApp import Glyphs, GSPath, GSNode`
- `from GlyphsApp.plugins import *` → `from GlyphsApp.plugins import FilterWithDialog`
- Version bump: `CFBundleVersion` 9 → 10, `CFBundleShortVersionString` 2.0.4 → 2.0.5

`import objc`, `from AppKit import NSAffineTransform, NSPoint` and the `math` imports were already explicit. No behavioural change; only the imports are made explicit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bs2JtfNiM4z5Duepf74nqX)_